### PR TITLE
fixed template id reference for determining parent folder for fields and properties

### DIFF
--- a/Sitecore.SharedSource.DataImporter/Providers/BaseDataMap.cs
+++ b/Sitecore.SharedSource.DataImporter/Providers/BaseDataMap.cs
@@ -405,7 +405,7 @@ namespace Sitecore.SharedSource.DataImporter.Providers
         /// <returns></returns>
         protected Item GetItemByTemplate(Item parent, string TemplateID) {
             IEnumerable<Item> x = from Item i in parent.GetChildren()
-                                  where i.Template.IsID(FieldsFolderID)
+                                  where i.Template.IsID(TemplateID)
                                   select i;
             return (x.Any()) ? x.First() : null;
         }


### PR DESCRIPTION
The method BaseDataMap.GetItemByTemplate() was ignoring the passed-in template id, and instead using the FieldsFolderID always.

The result is that there was no way to use properties in the Sitecore data mapper, and it would throw an exception if you had any fields defined.
